### PR TITLE
Make PDF link absolute

### DIFF
--- a/book/README.md
+++ b/book/README.md
@@ -1,7 +1,7 @@
 ## Welcome to GitHub for Developers
 > Note: This version of the manual is newer, and contains activities from our new curriculum. You can find the [legacy version of our training manual here](https://githubtraining.github.io/training-manual/legacy-manual.html).
 
-You can download a PDF version of this manual [here](training-manual.pdf).
+You can download a PDF version of this manual [here](https://githubtraining.github.io/training-manual/training-manual.pdf).
 
 Today you will embark on an exciting new adventure: learning how to use Git and GitHub.
 


### PR DESCRIPTION
It appears the GitBook requires absolute references to PDFs, so this PR fixes that. 