### PR TITLE
Add more specific instruction for creating partner merge conflict

### DIFF
--- a/book/12_resolving_merge_conflicts.md
+++ b/book/12_resolving_merge_conflicts.md
@@ -14,7 +14,7 @@ Merge conflicts are a natural and minor side effect of distributed version contr
 Let's try to create a merge conflict, and fix it together. You and a partner will each create separate branches, create a file with the same name, and then try to merge. The first will merge cleanly, the second will have a merge conflict. Work together to resolve the merge conflict.
 
 1. In our class repository, create the branch that you will be working on and name it something memorable like `USERNAME-conflict`.
-1. On your branch, create a new file. The file name must be the same file name that your partner uses. Make sure the content inside of the file is different.
+1. On your branch, create a new file. The file name must be the same file name that your partner uses. Make sure the content inside of the file is different, and that neither file is empty.
 1. Create a pull request in the class repository with `base: master` and `compare: USERNAME-conflict`.
 1. You will see that the _first_ pull request can merge well.
 1. When you see the merge conflict in the _second_ pull request, work together to resolve the merge conflict.


### PR DESCRIPTION
This pull request clarifies the instructions for creating a merge conflict together in class. 

@hectorsector This PR goes a slightly different suggestion than we discussed previously, but after thinking about it, this still seems simpler. I worry that having the students decide whose file to change, then having to decide what to change and which to eventually merge, could step on some toes since the changes would be to original content from the participants. 

(This is probably me being a helicopter teacher, but I'm envisioning a situation where someone writes a caption they think is funny, and it ends up getting overwritten by someone else in the class and they don't get to show off their joke.) 

![](https://media.giphy.com/media/fwLU2eTWcqRQA/giphy.gif)

With the current instructions, they still will get a merge conflict, but their original captions are unedited. 

cc @services-training, especially @hectorsector @beardofedu as we discussed this briefly at an impromptu Zoom meeting. Since this is a minor change, I will 🚢 with 1 👍 