### PR TITLE
Move setup for ci 

### DIFF
--- a/book/SUMMARY_CICD_FULLGH4D_CIRCLE.md
+++ b/book/SUMMARY_CICD_FULLGH4D_CIRCLE.md
@@ -20,6 +20,7 @@
 
 ## Project 3: GitHub Games
   * [Workflow Review](13_workflow_review_project_github_games.md)
+  * [Setting up CI/CD](32_setting_up_cicd.md)
   * [Git Bisect](14_git_bisect.md)
   * [Reverting Commits](15_reverting_commits.md)
   * [Helpful Git Commands](16_helpful_git_commands.md)
@@ -36,7 +37,6 @@
 ## Project 5: GitHub Games with CI/CD
   * [What is CI/CD?](30_whats_ci.md)
   * [Merging tests and `.yml` file](31_merging_tests.md)
-  * [Setting up CI/CD](32_setting_up_cicd.md)
   * [Interacting with CI/CD](33_interacting_cicd.md)
   * [Change The `.yml` file](34_change_yml.md)
 

--- a/book/SUMMARY_CICD_FULLGH4D_TRAVIS.md
+++ b/book/SUMMARY_CICD_FULLGH4D_TRAVIS.md
@@ -20,6 +20,7 @@
 
 ## Project 3: GitHub Games
   * [Workflow Review](13_workflow_review_project_github_games.md)
+  * [Setting up CI/CD](32_setting_up_cicd.md)
   * [Git Bisect](14_git_bisect.md)
   * [Reverting Commits](15_reverting_commits.md)
   * [Helpful Git Commands](16_helpful_git_commands.md)
@@ -36,7 +37,6 @@
 ## Project 5: GitHub Games with CI/CD
   * [What is CI/CD?](30_whats_ci.md)
   * [Merging tests and `.yml` file](31_merging_tests.md)
-  * [Setting up CI/CD](32_setting_up_cicd.md)
   * [Interacting with CI/CD](33_interacting_cicd.md)
   * [Change The `.yml` file](34_change_yml.md)
 


### PR DESCRIPTION
This pull request addresses the following 'to-do' in the [CI/CD training offering project](https://github.com/orgs/github/projects/132):

> Change order: When we're doing it WITH GitHub for Developers, enable testing before we do the workflow discussion and local work


@github/services-training what do you think? I'll 🚢 with 1 👍. 