### PR TITLE
Make h2 on page match title in navigation

### DIFF
--- a/book/32_setting_up_cicd.md
+++ b/book/32_setting_up_cicd.md
@@ -1,4 +1,4 @@
-## Fully functional class repository
+## Setting Up CI/CD
 
 We are going to start with tests built in to `github-games`, a repository we've already been working in.
 


### PR DESCRIPTION
This pull request addresses something that came up during teachbacks. The title on the page for setting up CI/CD doesn't currently match the title in the navigation. This pull request fixes that.

cc @beardofedu for 👍 and 👀 since he brought it to our attention