### PR TITLE
Change order in full classes - introduce CICD sooner

### DIFF
--- a/book/SUMMARY_CICD_FULLGH4D_CIRCLE.md
+++ b/book/SUMMARY_CICD_FULLGH4D_CIRCLE.md
@@ -19,8 +19,10 @@
   * [Resolving Merge Conflicts](12_resolving_merge_conflicts.md)
 
 ## Project 3: GitHub Games
-  * [Workflow Review](13_workflow_review_project_github_games.md)
+  * [What is CI/CD?](30_whats_ci.md)
   * [Setting up CI/CD](32_setting_up_cicd.md)
+  * [Merging tests and `.yml` file](31_merging_tests.md)
+  * [Workflow Review](13_workflow_review_project_github_games.md)
   * [Git Bisect](14_git_bisect.md)
   * [Reverting Commits](15_reverting_commits.md)
   * [Helpful Git Commands](16_helpful_git_commands.md)
@@ -34,9 +36,7 @@
   * [Cherry Picking](21_git_cherry_pick.md)
   * [Merge Strategies](22_merge_strategies_rebase.md)
 
-## Project 5: GitHub Games with CI/CD
-  * [What is CI/CD?](30_whats_ci.md)
-  * [Merging tests and `.yml` file](31_merging_tests.md)
+## Project 3 Continued: GitHub Games with CI/CD
   * [Interacting with CI/CD](33_interacting_cicd.md)
   * [Change The `.yml` file](34_change_yml.md)
 

--- a/book/SUMMARY_CICD_FULLGH4D_TRAVIS.md
+++ b/book/SUMMARY_CICD_FULLGH4D_TRAVIS.md
@@ -19,8 +19,10 @@
   * [Resolving Merge Conflicts](12_resolving_merge_conflicts.md)
 
 ## Project 3: GitHub Games
-  * [Workflow Review](13_workflow_review_project_github_games.md)
+  * [What is CI/CD?](30_whats_ci.md)
   * [Setting up CI/CD](32_setting_up_cicd.md)
+  * [Merging tests and `.yml` file](31_merging_tests.md)
+  * [Workflow Review](13_workflow_review_project_github_games.md)
   * [Git Bisect](14_git_bisect.md)
   * [Reverting Commits](15_reverting_commits.md)
   * [Helpful Git Commands](16_helpful_git_commands.md)
@@ -34,9 +36,7 @@
   * [Cherry Picking](21_git_cherry_pick.md)
   * [Merge Strategies](22_merge_strategies_rebase.md)
 
-## Project 5: GitHub Games with CI/CD
-  * [What is CI/CD?](30_whats_ci.md)
-  * [Merging tests and `.yml` file](31_merging_tests.md)
+## Project 3 Continued: GitHub Games with CI/CD
   * [Interacting with CI/CD](33_interacting_cicd.md)
   * [Change The `.yml` file](34_change_yml.md)
 


### PR DESCRIPTION
This addresses the item on the project board for the CI/CD course -

Change order in full classes to be:

1. Enable CI
1. Merge the tests branch
1. See the test fail
1. Do the workflow review

cc @github/services-training since this is a change that will affect how we teach the class, and cc all @github/services-training and especially @crichID for review 👍 