### PR TITLE
Add context for WHY in interacting with cicd section

### DIFF
--- a/book/33_interacting_cicd.md
+++ b/book/33_interacting_cicd.md
@@ -4,7 +4,7 @@
 
 The current test is looking to see if the URL in the `README.md` is correct. Using the GitHub flow, create a pull request that will have a failing build and **doesn't** have the correct URL. Our current test is found here: `tests/test_verifyurl.rb`
 
-The purpose of this section is to practice looking at the test and deciphering the error message. It can be overwhelming to look at all of the tool's feedback! If you'd like to dig in deeper, please do so, but if it feels like too much, focus on looking for the error message so you know what to fix. 
+The purpose of this section is to practice looking at the test and deciphering the error messages in a failing build. It can be overwhelming to look at all of the tool's feedback! If you'd like to dig in deeper, please do so, but if it feels like too much, focus on looking for the error message so you know what to fix. 
 
 
 1. Working locally, check out to the `gh-pages` branch: `git checkout gh-pages`.


### PR DESCRIPTION
This pull request adds a paragraph explaining the purpose of the 'interacting with CICD' section. This may get chopped as we iterate further on activities, but generally clarifies that we only are looking for the error message at this stage.

This need came about in teachbacks when it was a little unclear how deep we should dive into the tool's testing feedback. 

I will 🚢 with one 👍, specific pings to @hollenberry and @beardofedu, cc @github/services-training for awareness or drive-by-reviews