### PR TITLE
Add private emails note

### DIFF
--- a/book/05_local_git_configs.md
+++ b/book/05_local_git_configs.md
@@ -53,7 +53,12 @@ $ git config --global user.name "First Last"
 $ git config --global user.email "you@email.com"
 ```
 
-> Your name and email address will automatically be stored in the commits you make with Git. If you would like your email to remain private, GitHub allows you to generate a no-reply email address for your account. Click the **Keep my email address private** in the Settings > Emails section. After enabling this feature, you just need to enter the automatically generated ID+username@users.noreply.github.com when configuring your email. For example: `git config --global user.email 18249274+githubteacher@users.noreply.github.com`.
+> Your name and email address will automatically be stored in the commits you make with Git. If you would like your email to remain private, GitHub allows you to generate a no-reply email address for your account. Click the **Keep my email address private** in the [Settings > Emails section](https://github.com/settings/emails). After enabling this feature, you just need to enter the automatically generated `ID+username@users.noreply.github.com` when configuring your email.
+
+> For example:
+```sh
+git config --global user.email 18249274+githubteacher@users.noreply.github.com
+```
 
 ### Configuring autocrlf
 


### PR DESCRIPTION
Adding a note to the config section to identify the new Keep email private option. Based on this 

Closes https://github.com/github/services-training/issues/465. 