### PR TITLE
Choose which manual to preview

### DIFF
--- a/script/server
+++ b/script/server
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+option=$1
 # script/server: produce jekyll site of the manual
 
 set -e
@@ -16,35 +16,31 @@ then
   echo "3: GH4D + Travis CI"
   echo "4: Circle CI only"
   echo "5: Travis CI only"
-  echo "Which manual would you like to build?"
-  echo ""
-
+  echo "Which manual would you like to build? You can enter more than one number."
   read option
-else
-  option=$1
 fi
 
-if echo $option | grep -iq "1";
+if echo "$option" | grep -iq "1";
 then
   cp book/SUMMARY_GH4D.md book/SUMMARY.md
 fi
 
-if echo $option | grep -iq "2";
+if echo "$option" | grep -iq "2";
 then
   cp book/SUMMARY_CICD_FULLGH4D_CIRCLE.md book/SUMMARY.md
 fi
 
-if echo $option | grep -iq "3";
+if echo "$option" | grep -iq "3";
 then
   cp book/SUMMARY_CICD_FULLGH4D_TRAVIS.md book/SUMMARY.md
 fi
 
-if echo $option | grep -iq "4";
+if echo "$option" | grep -iq "4";
 then
   cp book/SUMMARY_CICDONLY_CIRCLE.md book/SUMMARY.md
 fi
 
-if echo $option | grep -iq "5";
+if echo "$option" | grep -iq "5";
 then
   cp book/SUMMARY_CICDONLY_TRAVIS.md book/SUMMARY.md
 fi


### PR DESCRIPTION
While I was [testing some additions](https://github.com/githubtraining/training-manual/pull/34#issuecomment-316411454), I struggled with remembering how to display each of the manuals I wanted to see. This PR adds some questions while running `script/server` that make it easy to tell the script which manual one wants rendered.

👀 🙏 @crichID since my bash scripting needs work.

/cc: @githubtraining/trainers for 👍 and awareness