### PR TITLE
Add details so we make PR fail first

### DIFF
--- a/book/33_interacting_cicd.md
+++ b/book/33_interacting_cicd.md
@@ -13,11 +13,14 @@ The purpose of this section is to practice the workflow, looking at the test, an
 
 1. Clone your copy of the repository: `git clone https://github.com/githubschool/github-games-USERNAME.git`.
 1. Checkout to the branch that is in the pull request, `git checkout CISERVICE-tests`.
-1. Edit the URL in the `README.md` so the tests will pass.
+1. Edit the URL in the `README.md` so the tests will _fail_.
 1. Commit the changes to your branch.
 1. If desired, you can check this test locally by running `ruby tests/test_verifyurl.rb` on this branch. Notice how different it will look on everyone's machines, and how having the tests run externally will smooth out the process. _(For this to work, you will need Ruby installed locally.)_
 1. Push your branch to GitHub: `git push`
-1. See that the tests are passing. If they aren't passing, look at the test to see what changes you still need to make.
+1. See that the tests are failing. 
+1. Working locally again, change the URL so the tests will _pass_. Commit those changes. 
+1. Push your branch up to the remote.
+1. Let the tests run again. If they aren't passing, look at the test to see what changes you still need to make.
 1. When all tests are passing, merge your Pull Request.
 1. Delete the branch on GitHub.
 1. Update your local copy of the repository: `git pull --prune`


### PR DESCRIPTION
This pull request changes the workflow a bit in reference to [this issue](https://github.com/github/services-training/issues/540#issuecomment-321822387). 

Before: 

1. We have them enable Circle CI.
1. We have them create a Pull Request for circleCI-tests
1. Right now, they won't see tests in the PR because CircleCI is looking for a commit in order to trigger the build/tests.
1. The next step in the manual tells them to clone, checkout to the circleCI-tests, and make the update to the README

After: 
1. Since we just enabled Circle CI, it is sitting in the background waiting for a new commit to trigger the first build.
1. Let's make a change to the URL in the README, but let's not fix it yet because we want to see a failing test.
1. Do it, push it, take a look at the failing tests.
1. Now let's fix it so our tests turn green.

This may lead to slightly different outcome in Travis (i.e. the tests might fail right off the bat in Travis but not Circle) but this workflow will not break anything in Travis, and is the most agnostic way to address the tests.

I'll 🚢 with one 👍 from @githubtraining/trainers 