### PR TITLE
Change status alias to just s

### DIFF
--- a/book/11_streamline_workflow_with_aliases.md
+++ b/book/11_streamline_workflow_with_aliases.md
@@ -27,7 +27,7 @@ $ git lol
 
 ```sh
 $ git config --global alias.co "checkout -b"
-$ git config --global alias.ss "status -s"
+$ git config --global alias.s "status -s"
 $ git config alias.dlb '!git checkout <DEFAULT-BRANCH> && git pull --prune && git branch --merged | grep -v "\*" | xargs -n 1 git branch -d'
 ```
 


### PR DESCRIPTION
Proposing to change the the status alias to just `s`, `ss` is not ok in some parts of this world 🗺.

:octocat: :sparkling_heart: