### PR TITLE
Sane Configs: add note about using --global only if its on own machine

### DIFF
--- a/book/05_local_git_configs.md
+++ b/book/05_local_git_configs.md
@@ -56,7 +56,7 @@ $ git config --global user.email "you@email.com"
 
 #### Git Config and Your Privacy
 
-The instructions for this exercise use the `--global` flag when identifying your `user.name` and `user.email` configuration settings. If you are currently using a computer without a private, personal account, don't apply the `--global` flag so the settings will only be stored in our assignment repository. If you work in another repository on this same computer, you will need to set these configuration options again. 
+The instructions for this exercise use the `--global` flag when identifying your `user.name` and `user.email` configuration settings. If you are currently using a computer without a private, personal account, don't apply the `--global` flag. This way, the settings will only be stored in our assignment repository. If you work in another repository on this same computer, you will need to set these configuration options again. 
 
 > For example:
 > ```sh


### PR DESCRIPTION
This pull request resolves https://github.com/githubtraining/training-manual/issues/16 by adding a note about using `--global` if it is on a shared computer. 

@githubtraining/trainers Can you please review and help edit the wording? 