### PR TITLE
Fix link to legacy manual PDF

### DIFF
--- a/book/README.md
+++ b/book/README.md
@@ -1,5 +1,5 @@
 ## Welcome to GitHub for Developers
-> Note: This version of the manual is newer, and contains activities from our new curriculum. You can find the [legacy version of our training manual here](https://githubtraining.github.io/training-manual/legacy-manual.html).
+> Note: This version of the manual is newer, and contains activities from our new curriculum. You can find the [legacy version of our training manual here](https://githubtraining.github.io/training-manual/legacy-manual.pdf).
 
 You can download a PDF version of this manual [here](https://githubtraining.github.io/training-manual/GH4D.pdf).
 


### PR DESCRIPTION
Related to #61, there's a link to the legacy manual in each of the different versions of the manual. However, that link is pointing to a ghost `html` file. This PR should generate a new set of manuals linking to the PDF.

Can 🚢 with one 👍.