### PR TITLE
Add enable GH Pages steps

### DIFF
--- a/book/33_interacting_cicd.md
+++ b/book/33_interacting_cicd.md
@@ -8,6 +8,14 @@ Now you will practice the GitHub Flow from beginning to end by updating the link
 
 > If you access this URL, you will see the text in the `README.md`. We have intentionally broken this repository so we can fix it together. The tests that we are merging also check for this URL.
 
+Before we begin practicing the GitHub Flow however, you need to enable GitHub Pages in your repository and grab the URL for your GitHub Pages site. 
+
+1. Access your repository settings by clicking the *Settings* tab.
+1. While on the *Options* pane (which is opened by default) scroll down to the *GitHub Pages* section.
+1. Click the *None* drop-down under *Source* and select `master branch`. 
+1. Click the *Save* button.
+1. Scroll back down to the GitHub Pages section, a new text box displays the URL for your published site. This is the URL you will be using to modify your `README.md` file later.
+
 The current test is looking to see if the URL in the `README.md` is correct. Using the GitHub flow, create a pull request that will have a failing build and **doesn't** have the correct URL. Our current test is found here: `tests/test_verifyurl.rb`
 
 The purpose of this section is to practice the workflow, looking at the test, and deciphering the error messages in a failing build. It can be overwhelming to look at all of the tool's feedback! If you'd like to dig in deeper, please do so, but if it feels like too much, focus on looking for the error message so you know what to fix.
@@ -19,7 +27,7 @@ The purpose of this section is to practice the workflow, looking at the test, an
 1. Commit the changes to your branch.
 1. Push your branch to GitHub: `git push`
 1. See that the tests are failing. 
-1. Working locally again, change the URL so the tests will _pass_. Commit those changes. 
+1. Working locally again, change the URL to the URL that was created when you enabled GitHub Pages in your repository so the tests will _pass_. Commit those changes. 
 1. Push your branch up to the remote.
 1. Let the tests run again. If they aren't passing, look at the test to see what changes you still need to make.
 1. When all tests are passing, merge your Pull Request.


### PR DESCRIPTION
Based on a comment in #52 , adding instructions for enabling GitHub Pages in the student repo.