### PR TITLE
Change merge conflict instructions to edit an existing file

### DIFF
--- a/book/12_resolving_merge_conflicts.md
+++ b/book/12_resolving_merge_conflicts.md
@@ -2,6 +2,8 @@
 
 When you work with a team (and even sometimes when you are working alone) you will occasionally create merge conflicts. At first, merge conflicts can be intimidating, but resolving them is actually quite easy. In this section you will learn how!
 
+These exercises will focus on the technical "how". In real merge conflicts, it's important to know who to ask in case you aren't sure how to resolve the conflict on your own. Usually it's a good idea to ask the person who made the conflicting changes, or someone who is a CODEOWNER on the file. 
+
 ### Local Merge Conflicts
 
 Merge conflicts are a natural and minor side effect of distributed version control. They only happen under very specific circumstances.


### PR DESCRIPTION
This pull request edits the instructions for the first merge conflict activity, so partners choose an existing file instead of creating a new file.

This avoids some problems that have been faced in the past with capitalization errors.

cc @githubtraining/trainers 

- @brianamarie as @githubteacher