### PR TITLE
Add GH4DJA to circle deploy cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
             - ./onlycicdcircle/
             - ./GH4D/
             - ./GH4M/
+            - ./GH4DJA/
 
   deploy:
     <<: *defaults


### PR DESCRIPTION
This PR attempts to fix the "deploy" step of the build for the new GH4D in Japanese.