### PR TITLE
Add GH4D in Japanese to main home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
     <ul>
       <li><a class="card" href="legacy-manual.pdf">GitHub for Developers Legacy Manual</a>
       <li><a class="card" href="GH4D/index">GitHub for Developers</a>
-      <li><a class="card" href="GH4J/index">GitHub for Developers (Japanese)</a>
+      <li><a class="card" href="GH4DJA/index">GitHub for Developers (Japanese)</a>
       <li><a class="card" href="fullcicdcircle/index">CI/CD and GitHub with Circle CI</a>
       <li><a class="card" href="fullcicdtravis/index">CI/CD and GitHub with Travis CI</a>
       <li><a class="card" href="GH4M/index">GitHub for Managers</a>


### PR DESCRIPTION
This PR adds a link to the Japanese manual. The manual is already live here: https://githubtraining.github.io/training-manual/GH4DJA/

cc @githubtraining/trainers for 👀 