### PR TITLE
Add git bisect reset to end of the short version

### DIFF
--- a/book/14_git_bisect.md
+++ b/book/14_git_bisect.md
@@ -39,3 +39,4 @@ Bisect can also run the tests on your code automatically. Let's try it again usi
 
 1. `git bisect start <bad-SHA> <good-SHA>`
 1. `git bisect run ls index.html`
+1. `git bisect reset`


### PR DESCRIPTION
Hello @githubtraining/trainers 👋 

This small tweak adds a `git bisect reset` at the end of the short version of git bisect. It is necessary to get out of bisecting mode, and some students have been getting stuck still bisecting before moving on to the rest.

I'll 🚢 with 1 👍. 
