### PR TITLE
Escape all variable usage

### DIFF
--- a/script/create-repo
+++ b/script/create-repo
@@ -7,8 +7,8 @@ reponame=$2
 collab=$3
 
 function checkavail () {
-  repoStatus=$(curl -s -i -u "$TOKEN_OWNER:$TEACHER_PAT" -X GET https://$INSTANCE_URL/repos/$CLASS_ORG/$reponame) >> log.out 2>&1
-  if echo $repoStatus | grep -iq "404"
+  repoStatus=$(curl -s -i -u "${TOKEN_OWNER}:${TEACHER_PAT}" -X GET "https://${INSTANCE_URL}/repos/${CLASS_ORG}/${reponame}") >> log.out 2>&1
+  if echo "${repoStatus}" | grep -iq "404"
   then
     echo "Cool, that name is available."
     createrepo
@@ -20,12 +20,12 @@ function checkavail () {
 }
 
 function createrepo () {
-  #create the repository on $INSTANCE_URL
-  curl -s -i -u "$TOKEN_OWNER:$TEACHER_PAT" -d "{ \"name\": \"$reponame\", \"description\": \"Let's learn about Git and GitHub\", \"homepage\": \"https://$CLASS_ORG.github.io/$reponame/\", \"private\": false, \"has_issues\": true, \"has_wiki\": true, \"has_downloads\": true}" -X POST https://$INSTANCE_URL/orgs/$CLASS_ORG/repos >> log.out 2>&1
+  #create the repository on ${INSTANCE_URL}
+  curl -s -i -u "${TOKEN_OWNER}:${TEACHER_PAT}" -d "{ \"name\": \"${reponame}\", \"description\": \"Let's learn about Git and GitHub\", \"homepage\": \"https://${CLASS_ORG}.github.io/${reponame}/\", \"private\": false, \"has_issues\": true, \"has_wiki\": true, \"has_downloads\": true}" -X POST "https://${INSTANCE_URL}/orgs/${CLASS_ORG}/repos" >> log.out 2>&1
   echo "Resting 5 seconds to allow repo creation to resolve"
   sleep 5
   #add collaborators
-  curl -s -i -u "$TOKEN_OWNER:$TEACHER_PAT" -X PUT https://$INSTANCE_URL/repos/$CLASS_ORG/$reponame/collaborators/$collab >> log.out 2>&1
+  curl -s -i -u "${TOKEN_OWNER}:${TEACHER_PAT}" -X PUT "https://${INSTANCE_URL}/repos/${CLASS_ORG}/${reponame}/collaborators/${collab}" >> log.out 2>&1
   clonerepo
 }
 
@@ -34,21 +34,21 @@ function clonerepo () {
   echo "Trying to clone a template repo from $ROOT_URL."
 
   if [ $ROOT_URL = "github.com" ]; then
-    git clone --bare https://github.com/githubtraining/$type $reponame >> log.out 2>&1
+    git clone --bare "https://github.com/githubtraining/${type}" "${reponame}" >> log.out 2>&1
   else
-    git clone --bare https://$TOKEN_OWNER:$TEACHER_PAT@$ROOT_URL/$CLASS_ORG/$type $reponame >> log.out 2>&1
+    git clone --bare "https://${TOKEN_OWNER}:${TEACHER_PAT}@$ROOT_URL/${CLASS_ORG}/${type}" "${reponame}" >> log.out 2>&1
     if [ $? -ne 0 ]; then
-      echo "!!! Couldn't clone template repo at all. Please grab a copy from https://github.com/githubtraining/$type and upload it to your GHE instance."
+      echo "!!! Couldn't clone template repo at all. Please grab a copy from https://github.com/githubtraining/${type} and upload it to your GHE instance."
       exit 1
     fi
   fi
 
-  pushd $reponame >> log.out 2>&1
-  git push --mirror https://$TOKEN_OWNER:$TEACHER_PAT@$ROOT_URL/$CLASS_ORG/$reponame >> log.out 2>&1
+  pushd "${reponame}" >> log.out 2>&1
+  git push --mirror "https://${TOKEN_OWNER}:${TEACHER_PAT}@$ROOT_URL/${CLASS_ORG}/${reponame}" >> log.out 2>&1
   echo "Resting 5 more seconds to allow push to resolve"
   sleep 5
   popd
-  rm -rf $reponame
+  rm -rf "${reponame}"
 }
 
 checkavail


### PR DESCRIPTION
### Situation

While setting up for class I ran into the below issue:

```shell
parse error: Invalid numeric literal at line 1, column 20
Oops, that repository name is already taken.
Please try a different name.
script/new-virtual: line 27: pushd: bring-me-wine: No such file or directory
script/new-virtual: line 42: popd: directory stack empty
ALL DONE: Remember to enable GitHub Pages on master.
Good luck with class!
```

Although it says `ALL DONE` no repo has been created.


### Proposed Fix
Escape all variables used in the script.


### Further Fixes (!?)
Might want to apply the same escaping to the other scripts under `script/`.
@githubtraining/trainers, what do you think? 