### PR TITLE
Update index.html to use GA tracking ID in script

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,13 +2,13 @@
 <html lang="en">
 <head>
   <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-127980839-1"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-3769691-104"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
 
-    gtag('config', 'UA-127980839-1');
+    gtag('config', 'UA-3769691-104');
   </script>
   <meta charset="UTF-8">
   <title>GitHub Training Manual</title>


### PR DESCRIPTION
@hectorsector Tracking ID `UA-127980839-1` is used temporarily to test out this implementation. If this works, then we will need to get a new Tracking ID tied to an official services-training gmail account since this ID is tied to my ppremk account. This PR is linked to #147 