### PR TITLE
Remove extra period

### DIFF
--- a/docs/17_tags_and_releases.md
+++ b/docs/17_tags_and_releases.md
@@ -14,7 +14,7 @@ To see all tags, type `git tag --list`.
 
 Another caveat with tags is that they are not automatically pushed up with commits. To push tags, type `git push --tags`.
 
- You can also set this as a default with configs using `git config push.followTags true` which will automatically push tags when their associated commits are pushed. [Read more about this config setting.](https://git-scm.com/docs/git-config/2.4.1#git-config-pushfollowTags).
+ You can also set this as a default with configs using `git config push.followTags true` which will automatically push tags when their associated commits are pushed. [Read more about this config setting](https://git-scm.com/docs/git-config/2.4.1#git-config-pushfollowTags).
 
 ### Releases
 


### PR DESCRIPTION
This removes an extra period found in the Tags and Releases content.

![image](https://user-images.githubusercontent.com/18329853/49487590-17aac480-f811-11e8-87a8-36cf49e52a24.png)

Any :+1: can merge this in, since it is so minor.

cc: @a-a-ron @brianamarie @crichID @hectorsector @hollenberry @ppremk 