### PR TITLE
Bug fix for a boundary condition

### DIFF
--- a/script/expire-repo
+++ b/script/expire-repo
@@ -14,7 +14,7 @@ function getpages () {
     else
       echo "There are $numPages pages"
   fi
-  while [ $numPages -gt 1 ]; do
+  while [ $numPages -gt 0 ]; do
     echo "Getting results for page $numPages"
     getrepos $numPages
     let numPages=numPages-1


### PR DESCRIPTION
This would never clean up everything it should since it was stopping when there was still one page of results left.

Doing this the quick and easy way since I have a large number of changes related to #174 that I need to port over from our GHE instance.