### PR TITLE
Removed \n from the comment message added to .${shell}rc

### DIFF
--- a/script/class-setup
+++ b/script/class-setup
@@ -110,7 +110,7 @@ echo "What kind of shell are you using?"
 echo "acceptable options: bash, zsh"
 read shell
 echo "Adding to your .${shell}rc..."
-echo "\n# added by github/training-manual class setup" >> $HOME/.${shell}rc
+echo "# added by github/training-manual class setup" >> $HOME/.${shell}rc
 echo "test -f \"$HOME/.trainingmanualrc\" && source \"$HOME/.trainingmanualrc\"" >> $HOME/.${shell}rc
 
 echo "ATTENTION: You must restart your open terminal sessions"


### PR DESCRIPTION
The `\n` was actually written to the stdout when logging in and processing the bash shell we would receive and error saying `\n#` is an invalid command.