### PR TITLE
Remove duplicate INSTANCE_URL export from class-setup script

### DIFF
--- a/script/class-setup
+++ b/script/class-setup
@@ -249,7 +249,6 @@ function InstanceURL ()
       ROOT_URL="github.com"
       INSTANCE_URL="api.github.com"
       echo "export ROOT_URL='$ROOT_URL'" >> "$HOME/$RC_FILE"
-      echo "export INSTANCE_URL='$INSTANCE_URL'" >> "$HOME/$RC_FILE"
     else
       #strip the API part
       ROOT_URL=$(echo "$NEW_URL" | sed -E 's/\/api\/v3//')


### PR DESCRIPTION
Line 252 duplicates line 222, adding a duplicate INSTANCE_URL variable to the RC file when running `script/class-setup`.