### PR TITLE
Markdown lint rule enforcement updates

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -18,8 +18,6 @@
 ###############
 # Rules by id #
 ###############
-MD013:
-  line_length: 808            # Line length
 MD024: false                  # Allow multiple headings with the same content
 MD026:                        # Trailing punctuation in heading
   punctuation: ".,;:!。，；:"  # List of characters not allowed


### PR DESCRIPTION
I updated the markdown lint rules being enforced in this repository to better fit the content. Certain rules conflicted with [docsify](https://github.com/docsifyjs/docsify) formatting requirements.