### PR TITLE
Update markdownlint rules

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -18,7 +18,7 @@
 ###############
 # Rules by id #
 ###############
-MD013: false                  # Line length
+MD013: false                  # Don't enforce line length
 MD024: false                  # Allow multiple headings with the same content
 MD026:                        # Trailing punctuation in heading
   punctuation: ".,;:!。，；:"  # List of characters not allowed


### PR DESCRIPTION
This pull request fixes an accidental enforcement of an 80 character line length and enforces rules with the `blank_lines` tag.