### PR TITLE
Replace accidentally removed line

### DIFF
--- a/script/new-virtual
+++ b/script/new-virtual
@@ -37,6 +37,8 @@ function GetDetails ()
   ###################
   read -r TEACHER
 
+  script/create-repo caption-this "$REPO_NAME" "$TEACHER"
+
   #######################
   # Load the error code #
   #######################


### PR DESCRIPTION
A line of code in the `new-virtual` script was unintentionally removed in #189. This restores that line.