### PR TITLE
Fix broken ROOT_URL logic

### DIFF
--- a/script/class-setup
+++ b/script/class-setup
@@ -237,7 +237,7 @@ function InstanceURL() {
   #######################
   # Check if github.com #
   #######################
-  if echo "$NEW_URL" | grep -iq "\<api.github.com\> "; then
+  if echo "$NEW_URL" | grep -iq "\<api.github.com\>"; then
     ROOT_URL="github.com"
     INSTANCE_URL="api.github.com"
     echo "export ROOT_URL='$ROOT_URL'" >> "$HOME/$RC_FILE"


### PR DESCRIPTION
A space that didn't belong in a grep command was causing the wrong ROOT_URL to be set when running through the `class-setup` script. This fixes that problem.