### PR TITLE
Add script for creating different starter repository

### DIFF
--- a/script/bootcamp-setup
+++ b/script/bootcamp-setup
@@ -1,205 +1,43 @@
 #!/usr/bin/env bash
+################################################################################
+############################## New Virtual #####################################
+################################################################################
 
-################################################################################
-############################### Class Setup ####################################
-################################################################################
+###########################################################
+# You must have a githubteacher token                     #
+# saved to your ENV variables in order to use this script #
+###########################################################
 
 ###########
 # GLOBALS #
 ###########
-NEW_NAME=''                 # Token owners name
-NEW_TOKEN=''                # Token owners PAT
-NEW_URL=''                  # Instance URL to GHE
-NEW_ORG=''                  # New instance GHE Organization
-SHELL=''                    # What shell the user is using
-RC_FILE='.trainingmanualrc' # RC file to load/pull data
+REPO_NAME=$1
 
 ################################################################################
 ########################## Functions Below #####################################
 ################################################################################
 ################################################################################
-#### Function ValidateJQ #######################################################
-function ValidateJQ() {
-  #########################
-  # Validate jq installed #
-  #########################
-  VALIDATE_JQ_CMD=$(command -v jq 2>&1)
+#### Function GetDetails #######################################################
+function GetDetails ()
+{
+  ####################
+  # Get them details #
+  ####################
+  echo "Let's add the class details to the README:"
+  echo "List the class dates."
+  echo "Example: March 10 - 13, 2017."
+  ###################
+  # Read in the var #
+  ###################
+  read -r CLASS_DATE
 
-  #######################
-  # Load the error code #
-  #######################
-  ERROR_CODE=$?
+  echo "Who is teaching? Without the @."
+  ###################
+  # Read in the var #
+  ###################
+  read -r TEACHER
 
-  ##############################
-  # Check the shell for errors #
-  ##############################
-  if [ $ERROR_CODE -ne 0 ]; then
-    echo "ERROR! Failed to find [jq] installed on system!"
-    echo "ERROR:[$VALIDATE_JQ_CMD]"
-    echo "Please install to system before next run!"
-    echo "grab it from https://stedolan.github.io/jq/download/"
-    exit 1
-  fi
-}
-################################################################################
-#### Function CreateRCFile #####################################################
-function CreateRCFile() {
-  ###########################
-  # Create training RC file #
-  ###########################
-  echo "==============================================="
-  echo "We'll create a file to store all training related configs."
-  echo "Checking for and creating [$HOME/$RC_FILE]"
-
-  ######################
-  # See if file exists #
-  ######################
-  if [ ! -f "$HOME/$RC_FILE" ]; then
-    echo "failed to find $HOME/$RC_FILE"
-    echo "Going to create file for you..."
-    CREATE_FILE=$(touch "$HOME/$RC_FILE" 2>&1)
-
-    #######################
-    # Load the error code #
-    #######################
-    ERROR_CODE=$?
-
-    ##############################
-    # Check the shell for errors #
-    ##############################
-    if [ $ERROR_CODE -ne 0 ]; then
-      echo "ERROR! Failed to create file!"
-      echo "ERROR:[$CREATE_FILE]"
-      exit 1
-    fi
-  ###########################
-  # The file already exists #
-  ###########################
-  else
-    echo "The file:[$HOME/$RC_FILE] exists in the system."
-    echo "Would you like to recreate the file?"
-    echo "(Y)es or (N)o, followed by [ENTER]"
-    ##################
-    # Read the input #
-    ##################
-    read -r CREATE_FILE
-
-    if [[ "$CREATE_FILE" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
-      ########################
-      # We have a yes answer #
-      ########################
-      echo "Deleteting the file to recreate it..."
-      DELETE_AND_CREATE_FILE=$(
-        rm -f "$HOME/$RC_FILE"
-        touch "$HOME/$RC_FILE" 2>&1
-      )
-
-      #######################
-      # Load the error code #
-      #######################
-      ERROR_CODE=$?
-
-      ##############################
-      # Check the shell for errors #
-      ##############################
-      if [ $ERROR_CODE -ne 0 ]; then
-        echo "ERROR! Failed to delete and recreate file!"
-        echo "ERROR:[$DELETE_AND_CREATE_FILE]"
-        exit 1
-      fi
-    else
-      #################################
-      # Leaving current file in place #
-      #################################
-      echo "Leaving current file in place..."
-      echo ""
-      echo "Current Env Vars:"
-      echo "==============================================="
-      echo "TOKEN_OWNER=[$TOKEN_OWNER]"
-      echo "TEACHER_PAT=[NOT DISPLAYED]"
-      echo "INSTANCE_URL=[$INSTANCE_URL]"
-      echo "ROOT_URL=[$ROOT_URL]"
-      echo "CLASS_ORG=[$CLASS_ORG]"
-      echo "SURVEY_URL=[$SURVEY_URL]"
-      echo "APPT_URL=[$APPT_URL]"
-      echo "==============================================="
-      echo ""
-      echo "NOTE: If any of these appear to be incorrect,"
-      echo "please destroy the file and restart your shell."
-      echo ""
-
-      ####################################
-      # Exit the shell - we're done here #
-      ####################################
-      exit 0
-    fi
-  fi
-
-  echo "==============================================="
-  echo ""
-  echo "==============================================="
-}
-################################################################################
-#### Function TokenOwner #######################################################
-function TokenOwner() {
-  #######################
-  # Get the token Owner #
-  #######################
-  echo "It looks like we'll need to add the TOKEN_OWNER var"
-  echo "to your ~/$RC_FILE. Please type the github username"
-  echo "you'll be using today and we'll add this automatically. Remember, this"
-  echo "user will need to have full admin access to the teaching organization."
-  #####################
-  # Read in the input #
-  #####################
-  read -r NEW_NAME
-
-  #############################
-  # Write the var to the file #
-  #############################
-  echo "export TOKEN_OWNER='$NEW_NAME'" >> "$HOME/$RC_FILE"
-  echo "TOKEN_OWNER = $TOKEN_OWNER"
-  echo "==============================================="
-}
-################################################################################
-#### Function DemoPAT ##########################################################
-function DemoPAT() {
-  ##############################
-  # See if we have teacher PAT #
-  ##############################
-  echo "It looks like we need to add the"
-  echo "TEACHER_PAT var to your ~/$RC_FILE."
-  echo "Please generate a Personal Access token on the"
-  echo "account you'll be teaching from and paste it here."
-  echo "(Note: the token will not be displayed when entered)"
-  #####################
-  # Read in the token #
-  #####################
-  read -r -s NEW_TOKEN
-
-  #############################
-  # Write the var to the file #
-  #############################
-  echo "export TEACHER_PAT='$NEW_TOKEN'" >> "$HOME/$RC_FILE"
-  echo "TEACHER_PAT=[NOT DISPLAYED]"
-  echo "==============================================="
-}
-################################################################################
-#### Function InstanceURL ######################################################
-function InstanceURL() {
-  ###############################
-  # See if we have instance URL #
-  ###############################
-  echo "It looks like you need to add the"
-  echo "INSTANCE_URL var to your ~/$RC_FILE. Please type the"
-  echo "root endpoint for your github instance."
-  echo "For example: api.github.com OR github.mycompany.com/api/v3"
-  ##################
-  # Read the input #
-  ##################
-  read -r NEW_URL
-  echo "Checking if '$NEW_URL' is accessible... (this may take several moments)"
-  curl -s "$NEW_URL" >> log.out 2>&1
+  script/create-repo caption-this "$REPO_NAME" "$TEACHER"
 
   #######################
   # Load the error code #
@@ -210,192 +48,90 @@ function InstanceURL() {
   # Check the shell for errors #
   ##############################
   if [ $ERROR_CODE -eq 0 ]; then
-    echo "API endpoint verified"
-    echo "export INSTANCE_URL='$NEW_URL'" >> "$HOME/$RC_FILE"
-  else
-    echo "Can't access your API via that URL, perhaps it needs authentication, checking..."
-    ###################
-    # Check with Auth #
-    ###################
-    echo "Checking if '$NEW_URL' is accessible with authentication..."
-    if [[ $(curl -s -u "$NEW_NAME:$NEW_TOKEN" "https://$NEW_URL/" | jq .message) = null ]]; then
-      echo "API endpoint + authentication verified"
-      echo "export INSTANCE_URL='$NEW_URL'" >> "$HOME/$RC_FILE"
+    git clone "https://$TOKEN_OWNER:$TEACHER_PAT@$ROOT_URL/$CLASS_ORG/$REPO_NAME" "$REPO_NAME" >> log.out 2>&1
+    pushd "$REPO_NAME" || return
+    # shellcheck disable=SC2129
+    git config user.name "$TOKEN_OWNER" >> log.out 2>&1
+    # shellcheck disable=SC1102
+    GITHUB_EMAIL=$((curl -s -u "$TOKEN_OWNER:$TEACHER_PAT" -X GET "https://$INSTANCE_URL/users/$TOKEN_OWNER" | jq .email) | (sed -e 's/^"//' -e 's/"$//')) >> log.out 2>&1
+    git config user.email "$GITHUB_EMAIL" >> log.out 2>&1
+    if [ "$OSTYPE" = "msys" ]; then
+      # shellcheck disable=SC2129
+      sed -i "s/THIS-DATE/$CLASS_DATE/g" README.md >> log.out 2>&1
+      sed -i "s/TEACHER-HANDLE/$TEACHER/g" README.md >> log.out 2>&1
+      sed -i "s|SURVEY-LINK|<$SURVEY_URL>|g" README.md >> log.out 2>&1
+      sed -i "s|caption-this|$REPO_NAME|g" _config.yml >> log.out 2>&1
     else
-      echo "Can't make an authenticated request to the API."
-      exit 1
+      # shellcheck disable=SC2129
+      sed -i "" "s/THIS-DATE/$CLASS_DATE/g" README.md >> log.out 2>&1
+      sed -i "" "s/TEACHER-HANDLE/$TEACHER/g" README.md >> log.out 2>&1
+      sed -i "" "s|SURVEY-LINK|<$SURVEY_URL>|g" README.md >> log.out 2>&1
+      sed -i "" "s|caption-this|$REPO_NAME|g" _config.yml >> log.out 2>&1
     fi
-  fi
-
-  #########################
-  # Set the vars to empty #
-  #########################
-  ROOT_URL=''
-  INSTANCE_URL=''
-
-  #######################
-  # Check if github.com #
-  #######################
-  if echo "$NEW_URL" | grep -iq "\<api.github.com\>"; then
-    ROOT_URL="github.com"
-    INSTANCE_URL="api.github.com"
-    echo "export ROOT_URL='$ROOT_URL'" >> "$HOME/$RC_FILE"
+    # shellcheck disable=SC2129
+    git add README.md >> log.out 2>&1
+    git commit -m "create class README" >> log.out 2>&1
+    git add _config.yml >> log.out 2>&1
+    git commit -m "update config with class information" >> log.out 2>&1
+    git push "https://$TOKEN_OWNER:$TEACHER_PAT@$ROOT_URL/$CLASS_ORG/$REPO_NAME" >> log.out 2>&1
+    git config --local --unset user.name >> log.out 2>&1
+    git config --local --unset user.email >> log.out 2>&1
+    popd || return
+    rm -rf "$REPO_NAME" >> log.out 2>&1
+    ########################
+    # Call the pretty repo #
+    ########################
+    PrettyRepo "$TEACHER"
+  elif [ $ERROR_CODE -eq 2 ]; then
+    echo "!!! Please try running option 1 again and picking a unique repository name."
   else
-    #strip the API part
-    ROOT_URL=$(echo "$NEW_URL" | sed -E 's/\/api\/v3//')
-    INSTANCE_URL=$NEW_URL
-    echo "export ROOT_URL='$ROOT_URL'" >> "$HOME/$RC_FILE"
+    echo "!!! Wasn't able to clone the template repo from github.com. Are you behind a firewall?"
   fi
-
-  ##########
-  # Prints #
-  ##########
-  echo "INSTANCE_URL=[$INSTANCE_URL]"
-  echo "ROOT_URL=[$ROOT_URL]"
-  echo "==============================================="
 }
 ################################################################################
-#### Function ClassOrg #########################################################
-function ClassOrg() {
-  ##########################
-  # See if we have the Org #
-  ##########################
-  echo "It looks like you need to add the CLASS_ORG var"
-  echo "to your ~/$RC_FILE. Please type the organization name"
-  echo "used for github training on your instance."
-  echo "For example: githubschool"
-  ##################
-  # Read the input #
-  ##################
-  read -r NEW_ORG
-
-  ###################
-  # Validate access #
-  ###################
-  echo "Checking if $NEW_ORG is accessible via the API..."
-  if [[ $(curl -s -u "$NEW_NAME:$NEW_TOKEN" "https://$NEW_URL/orgs/$NEW_ORG" | jq .message) = null ]]; then
-    echo "That organization was verified."
-    echo "export CLASS_ORG='$NEW_ORG'" >> "$HOME/$RC_FILE"
-  else
-    echo "Can't access the organization via the API."
-    exit 1
-  fi
-
-  ##########
-  # Prints #
-  ##########
-  echo "CLASS_ORG=[$CLASS_ORG]"
-  echo "==============================================="
+#### Function PrettyRepo #######################################################
+function PrettyRepo ()
+{
+  TEACHER=$1
+  #set branch protections
+  # shellcheck disable=SC2129
+  curl -s -i -H "Accept: application/vnd.github.loki-preview+json" -u "$TOKEN_OWNER:$TEACHER_PAT" -d "{ \"required_status_checks\": { \"strict\": false, \"contexts\": [ \"null\" ] }, \"required_pull_request_reviews\": { \"dismissal_restrictions\": { \"users\": [ \"$TEACHER\" ], \"teams\": [ \"null\" ] }, \"dismiss_stale_reviews\": false }, \"enforce_admins\": false, \"restrictions\": { \"users\": [ \"$TEACHER\", \"$TOKEN_OWNER\" ], \"teams\": [ \"null\" ] } }" -X PUT "https://$INSTANCE_URL/repos/$CLASS_ORG/$REPO_NAME/branches/master/protection" >> log.out 2>&1
+  curl -s -i -H "Accept: application/vnd.github.loki-preview+json" -u "$TOKEN_OWNER:$TEACHER_PAT" -X DELETE "https://$INSTANCE_URL/repos/$CLASS_ORG/$REPO_NAME/branches/master/protection/required_status_checks" >> log.out 2>&1
+  #delete labels other than question, duplicate, enhancement, and help wanted
+  curl -s -i -u "$TOKEN_OWNER:$TEACHER_PAT" -X DELETE "https://$INSTANCE_URL/repos/$CLASS_ORG/$REPO_NAME/labels/bug" >> log.out 2>&1
+  curl -s -i -u "$TOKEN_OWNER:$TEACHER_PAT" -X DELETE "https://$INSTANCE_URL/repos/$CLASS_ORG/$REPO_NAME/labels/invalid" >> log.out 2>&1
+  curl -s -i -u "$TOKEN_OWNER:$TEACHER_PAT" -X DELETE "https://$INSTANCE_URL/repos/$CLASS_ORG/$REPO_NAME/labels/wontfix" >> log.out 2>&1
+  #open the issue to be added as a collaborator
+  curl -s -i -u "$TOKEN_OWNER:$TEACHER_PAT" -d "{ \"title\": \"Comment here to be added as a collaborator\", \"body\": \"### Comment below - you can say anything \n We will all be using this repository today. Even though it's public right now, you will not be able to make changes until you're given the correct permissions. We've automated this process via the GitHub API and some fancy chatops. Once you comment, we will add you as a collaborator. \n\n  You'll also start to receive a lot of emails. (:exclamation:) You can slow these down immediately by clicking the 'Unwatch' button and selecting either the 'Not watching' or 'Ignoring' option.\"}" -X POST "https://$INSTANCE_URL/repos/$CLASS_ORG/$REPO_NAME/issues" >> log.out 2>&1
+  #add a project to the repo and grab the project id
+  PROJ_ID=$(curl -s -H "Accept: application/vnd.github.inertia-preview+json" -u "$TOKEN_OWNER:$TEACHER_PAT" -d "{ \"name\": \"Class Activity: Caption Contest\", \"body\": \"Let's see who can create the best captions for our collection of memes.\"}" -X POST "https://$INSTANCE_URL/repos/$CLASS_ORG/$REPO_NAME/projects" | jq .id) >> log.out 2>&1
+  #add columns to project
+  COLUMN_ONE=$(curl -s -H "Accept: application/vnd.github.inertia-preview+json" -u "$TOKEN_OWNER:$TEACHER_PAT" -d "{ \"name\": \"To-Do\"}" -X POST "https://$INSTANCE_URL/projects/$PROJ_ID/columns" | jq .id) >> log.out 2>&1
+  # shellcheck disable=SC2034
+  COLUMN_TWO=$(curl -s -H "Accept: application/vnd.github.inertia-preview+json" -u "$TOKEN_OWNER:$TEACHER_PAT" -d "{ \"name\": \"Extended Projects\"}" -X POST "https://$INSTANCE_URL/projects/$PROJ_ID/columns" | jq .id) >> log.out 2>&1
+  curl -s -H "Accept: application/vnd.github.inertia-preview+json" -u "$TOKEN_OWNER:$TEACHER_PAT" -d "{ \"name\": \"In-Progress\"}" -X POST "https://$INSTANCE_URL/projects/$PROJ_ID/columns" >> log.out 2>&1
+  curl -s -H "Accept: application/vnd.github.inertia-preview+json" -u "$TOKEN_OWNER:$TEACHER_PAT" -d "{ \"name\": \"Done\"}" -X POST "https://$INSTANCE_URL/projects/$PROJ_ID/columns" >> log.out 2>&1
+  #add cards to each column
+  curl -s -i -H "Accept: application/vnd.github.inertia-preview+json" -u "$TOKEN_OWNER:$TEACHER_PAT" -d "{ \"note\": \"Each student will update their file in the _posts directory with an image and a caption.\"}" -X POST "https://$INSTANCE_URL/projects/columns/$COLUMN_ONE/cards" >> log.out 2>&1
+  FinishStrong
 }
 ################################################################################
-#### Function SurveyURL ##########################################################
-function SurveyURL() {
-  #################################
-  # See if we have the survey URL #
-  #################################
-  echo "To include a link to a survey in your class repository,"
-  echo "add the survey URL to your ~/$RC_FILE by pasting it below:"
-  ##################
-  # Read the input #
-  ##################
-  read -r SURVEY_URL
-  echo "export SURVEY_URL='$SURVEY_URL'" >> "$HOME/$RC_FILE"
-
-  ##########
-  # Prints #
-  ##########
-  echo "SURVEY_URL=[$SURVEY_URL]"
-  echo "==============================================="
-}
-################################################################################
-#### Function ApptURL ##########################################################
-function ApptURL() {
-  ###############################
-  # See if we have the appt URL #
-  ###############################
-  echo "If you will offer 1:1 appointments with your students,"
-  echo "you will need to add the booking URL to your ~/$RC_FILE"
-  echo "by pasting it below:"
-  ##################
-  # Read the input #
-  ##################
-  read -r APPT_URL
-  echo "export APPT_URL='$APPT_URL'" >> "$HOME/$RC_FILE"
-
-  ##########
-  # Prints #
-  ##########
-  echo "APPT_URL=[$APPT_URL]"
-  echo "==============================================="
-}
-################################################################################
-#### Function ShellCheck #######################################################
-function ShellCheck() {
-  #########################
-  # Check the users shell #
-  #########################
-  echo "What kind of shell are you using?"
-  echo "acceptable options: bash, zsh"
-  ##################
-  # Read the input #
-  ##################
-  read -r SHELL
-  echo "Adding to your .${SHELL}rc..."
-  # shellcheck disable=SC2028
-  echo "# added by github/training-manual class setup" >> "$HOME/.${SHELL}rc"
-  echo "test -f \"$HOME/$RC_FILE\" && source \"$HOME/$RC_FILE\"" >> "$HOME/.${SHELL}rc"
-
-  ##########
-  # Prints #
-  ##########
-  echo "ATTENTION: You must restart your open terminal sessions"
-  echo "for changes to take effect."
+#### Function FinishStrong #####################################################
+function FinishStrong ()
+{
+  echo "ALL DONE: Remember to enable GitHub Pages on master."
+  echo "Good luck with class!"
 }
 ################################################################################
 ############################### MAIN ###########################################
 ################################################################################
 
-###############
-# Validate jq #
-###############
-ValidateJQ
+##########
+# Header #
+##########
+echo "This script creates a new caption-this repository"
 
-##################
-# Create rc file #
-##################
-CreateRCFile
-
-#######################
-# Get the token owner #
-#######################
-TokenOwner
-
-#######################
-# Get the teacher PAT #
-#######################
-DemoPAT
-
-########################
-# Get the instance URL #
-########################
-InstanceURL
-
-#####################
-# Get the class org #
-#####################
-ClassOrg
-
-######################
-# Get the survey URL #
-######################
-SurveyURL
-
-####################
-# Get the appt URL #
-####################
-ApptURL
-
-#########################
-# Check the users shell #
-#########################
-ShellCheck
+###################
+# Get the details #
+###################
+GetDetails

--- a/script/bootcamp-setup
+++ b/script/bootcamp-setup
@@ -1,0 +1,401 @@
+#!/usr/bin/env bash
+
+################################################################################
+############################### Class Setup ####################################
+################################################################################
+
+###########
+# GLOBALS #
+###########
+NEW_NAME=''                 # Token owners name
+NEW_TOKEN=''                # Token owners PAT
+NEW_URL=''                  # Instance URL to GHE
+NEW_ORG=''                  # New instance GHE Organization
+SHELL=''                    # What shell the user is using
+RC_FILE='.trainingmanualrc' # RC file to load/pull data
+
+################################################################################
+########################## Functions Below #####################################
+################################################################################
+################################################################################
+#### Function ValidateJQ #######################################################
+function ValidateJQ() {
+  #########################
+  # Validate jq installed #
+  #########################
+  VALIDATE_JQ_CMD=$(command -v jq 2>&1)
+
+  #######################
+  # Load the error code #
+  #######################
+  ERROR_CODE=$?
+
+  ##############################
+  # Check the shell for errors #
+  ##############################
+  if [ $ERROR_CODE -ne 0 ]; then
+    echo "ERROR! Failed to find [jq] installed on system!"
+    echo "ERROR:[$VALIDATE_JQ_CMD]"
+    echo "Please install to system before next run!"
+    echo "grab it from https://stedolan.github.io/jq/download/"
+    exit 1
+  fi
+}
+################################################################################
+#### Function CreateRCFile #####################################################
+function CreateRCFile() {
+  ###########################
+  # Create training RC file #
+  ###########################
+  echo "==============================================="
+  echo "We'll create a file to store all training related configs."
+  echo "Checking for and creating [$HOME/$RC_FILE]"
+
+  ######################
+  # See if file exists #
+  ######################
+  if [ ! -f "$HOME/$RC_FILE" ]; then
+    echo "failed to find $HOME/$RC_FILE"
+    echo "Going to create file for you..."
+    CREATE_FILE=$(touch "$HOME/$RC_FILE" 2>&1)
+
+    #######################
+    # Load the error code #
+    #######################
+    ERROR_CODE=$?
+
+    ##############################
+    # Check the shell for errors #
+    ##############################
+    if [ $ERROR_CODE -ne 0 ]; then
+      echo "ERROR! Failed to create file!"
+      echo "ERROR:[$CREATE_FILE]"
+      exit 1
+    fi
+  ###########################
+  # The file already exists #
+  ###########################
+  else
+    echo "The file:[$HOME/$RC_FILE] exists in the system."
+    echo "Would you like to recreate the file?"
+    echo "(Y)es or (N)o, followed by [ENTER]"
+    ##################
+    # Read the input #
+    ##################
+    read -r CREATE_FILE
+
+    if [[ "$CREATE_FILE" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
+      ########################
+      # We have a yes answer #
+      ########################
+      echo "Deleteting the file to recreate it..."
+      DELETE_AND_CREATE_FILE=$(
+        rm -f "$HOME/$RC_FILE"
+        touch "$HOME/$RC_FILE" 2>&1
+      )
+
+      #######################
+      # Load the error code #
+      #######################
+      ERROR_CODE=$?
+
+      ##############################
+      # Check the shell for errors #
+      ##############################
+      if [ $ERROR_CODE -ne 0 ]; then
+        echo "ERROR! Failed to delete and recreate file!"
+        echo "ERROR:[$DELETE_AND_CREATE_FILE]"
+        exit 1
+      fi
+    else
+      #################################
+      # Leaving current file in place #
+      #################################
+      echo "Leaving current file in place..."
+      echo ""
+      echo "Current Env Vars:"
+      echo "==============================================="
+      echo "TOKEN_OWNER=[$TOKEN_OWNER]"
+      echo "TEACHER_PAT=[NOT DISPLAYED]"
+      echo "INSTANCE_URL=[$INSTANCE_URL]"
+      echo "ROOT_URL=[$ROOT_URL]"
+      echo "CLASS_ORG=[$CLASS_ORG]"
+      echo "SURVEY_URL=[$SURVEY_URL]"
+      echo "APPT_URL=[$APPT_URL]"
+      echo "==============================================="
+      echo ""
+      echo "NOTE: If any of these appear to be incorrect,"
+      echo "please destroy the file and restart your shell."
+      echo ""
+
+      ####################################
+      # Exit the shell - we're done here #
+      ####################################
+      exit 0
+    fi
+  fi
+
+  echo "==============================================="
+  echo ""
+  echo "==============================================="
+}
+################################################################################
+#### Function TokenOwner #######################################################
+function TokenOwner() {
+  #######################
+  # Get the token Owner #
+  #######################
+  echo "It looks like we'll need to add the TOKEN_OWNER var"
+  echo "to your ~/$RC_FILE. Please type the github username"
+  echo "you'll be using today and we'll add this automatically. Remember, this"
+  echo "user will need to have full admin access to the teaching organization."
+  #####################
+  # Read in the input #
+  #####################
+  read -r NEW_NAME
+
+  #############################
+  # Write the var to the file #
+  #############################
+  echo "export TOKEN_OWNER='$NEW_NAME'" >> "$HOME/$RC_FILE"
+  echo "TOKEN_OWNER = $TOKEN_OWNER"
+  echo "==============================================="
+}
+################################################################################
+#### Function DemoPAT ##########################################################
+function DemoPAT() {
+  ##############################
+  # See if we have teacher PAT #
+  ##############################
+  echo "It looks like we need to add the"
+  echo "TEACHER_PAT var to your ~/$RC_FILE."
+  echo "Please generate a Personal Access token on the"
+  echo "account you'll be teaching from and paste it here."
+  echo "(Note: the token will not be displayed when entered)"
+  #####################
+  # Read in the token #
+  #####################
+  read -r -s NEW_TOKEN
+
+  #############################
+  # Write the var to the file #
+  #############################
+  echo "export TEACHER_PAT='$NEW_TOKEN'" >> "$HOME/$RC_FILE"
+  echo "TEACHER_PAT=[NOT DISPLAYED]"
+  echo "==============================================="
+}
+################################################################################
+#### Function InstanceURL ######################################################
+function InstanceURL() {
+  ###############################
+  # See if we have instance URL #
+  ###############################
+  echo "It looks like you need to add the"
+  echo "INSTANCE_URL var to your ~/$RC_FILE. Please type the"
+  echo "root endpoint for your github instance."
+  echo "For example: api.github.com OR github.mycompany.com/api/v3"
+  ##################
+  # Read the input #
+  ##################
+  read -r NEW_URL
+  echo "Checking if '$NEW_URL' is accessible... (this may take several moments)"
+  curl -s "$NEW_URL" >> log.out 2>&1
+
+  #######################
+  # Load the error code #
+  #######################
+  ERROR_CODE=$?
+
+  ##############################
+  # Check the shell for errors #
+  ##############################
+  if [ $ERROR_CODE -eq 0 ]; then
+    echo "API endpoint verified"
+    echo "export INSTANCE_URL='$NEW_URL'" >> "$HOME/$RC_FILE"
+  else
+    echo "Can't access your API via that URL, perhaps it needs authentication, checking..."
+    ###################
+    # Check with Auth #
+    ###################
+    echo "Checking if '$NEW_URL' is accessible with authentication..."
+    if [[ $(curl -s -u "$NEW_NAME:$NEW_TOKEN" "https://$NEW_URL/" | jq .message) = null ]]; then
+      echo "API endpoint + authentication verified"
+      echo "export INSTANCE_URL='$NEW_URL'" >> "$HOME/$RC_FILE"
+    else
+      echo "Can't make an authenticated request to the API."
+      exit 1
+    fi
+  fi
+
+  #########################
+  # Set the vars to empty #
+  #########################
+  ROOT_URL=''
+  INSTANCE_URL=''
+
+  #######################
+  # Check if github.com #
+  #######################
+  if echo "$NEW_URL" | grep -iq "\<api.github.com\>"; then
+    ROOT_URL="github.com"
+    INSTANCE_URL="api.github.com"
+    echo "export ROOT_URL='$ROOT_URL'" >> "$HOME/$RC_FILE"
+  else
+    #strip the API part
+    ROOT_URL=$(echo "$NEW_URL" | sed -E 's/\/api\/v3//')
+    INSTANCE_URL=$NEW_URL
+    echo "export ROOT_URL='$ROOT_URL'" >> "$HOME/$RC_FILE"
+  fi
+
+  ##########
+  # Prints #
+  ##########
+  echo "INSTANCE_URL=[$INSTANCE_URL]"
+  echo "ROOT_URL=[$ROOT_URL]"
+  echo "==============================================="
+}
+################################################################################
+#### Function ClassOrg #########################################################
+function ClassOrg() {
+  ##########################
+  # See if we have the Org #
+  ##########################
+  echo "It looks like you need to add the CLASS_ORG var"
+  echo "to your ~/$RC_FILE. Please type the organization name"
+  echo "used for github training on your instance."
+  echo "For example: githubschool"
+  ##################
+  # Read the input #
+  ##################
+  read -r NEW_ORG
+
+  ###################
+  # Validate access #
+  ###################
+  echo "Checking if $NEW_ORG is accessible via the API..."
+  if [[ $(curl -s -u "$NEW_NAME:$NEW_TOKEN" "https://$NEW_URL/orgs/$NEW_ORG" | jq .message) = null ]]; then
+    echo "That organization was verified."
+    echo "export CLASS_ORG='$NEW_ORG'" >> "$HOME/$RC_FILE"
+  else
+    echo "Can't access the organization via the API."
+    exit 1
+  fi
+
+  ##########
+  # Prints #
+  ##########
+  echo "CLASS_ORG=[$CLASS_ORG]"
+  echo "==============================================="
+}
+################################################################################
+#### Function SurveyURL ##########################################################
+function SurveyURL() {
+  #################################
+  # See if we have the survey URL #
+  #################################
+  echo "To include a link to a survey in your class repository,"
+  echo "add the survey URL to your ~/$RC_FILE by pasting it below:"
+  ##################
+  # Read the input #
+  ##################
+  read -r SURVEY_URL
+  echo "export SURVEY_URL='$SURVEY_URL'" >> "$HOME/$RC_FILE"
+
+  ##########
+  # Prints #
+  ##########
+  echo "SURVEY_URL=[$SURVEY_URL]"
+  echo "==============================================="
+}
+################################################################################
+#### Function ApptURL ##########################################################
+function ApptURL() {
+  ###############################
+  # See if we have the appt URL #
+  ###############################
+  echo "If you will offer 1:1 appointments with your students,"
+  echo "you will need to add the booking URL to your ~/$RC_FILE"
+  echo "by pasting it below:"
+  ##################
+  # Read the input #
+  ##################
+  read -r APPT_URL
+  echo "export APPT_URL='$APPT_URL'" >> "$HOME/$RC_FILE"
+
+  ##########
+  # Prints #
+  ##########
+  echo "APPT_URL=[$APPT_URL]"
+  echo "==============================================="
+}
+################################################################################
+#### Function ShellCheck #######################################################
+function ShellCheck() {
+  #########################
+  # Check the users shell #
+  #########################
+  echo "What kind of shell are you using?"
+  echo "acceptable options: bash, zsh"
+  ##################
+  # Read the input #
+  ##################
+  read -r SHELL
+  echo "Adding to your .${SHELL}rc..."
+  # shellcheck disable=SC2028
+  echo "# added by github/training-manual class setup" >> "$HOME/.${SHELL}rc"
+  echo "test -f \"$HOME/$RC_FILE\" && source \"$HOME/$RC_FILE\"" >> "$HOME/.${SHELL}rc"
+
+  ##########
+  # Prints #
+  ##########
+  echo "ATTENTION: You must restart your open terminal sessions"
+  echo "for changes to take effect."
+}
+################################################################################
+############################### MAIN ###########################################
+################################################################################
+
+###############
+# Validate jq #
+###############
+ValidateJQ
+
+##################
+# Create rc file #
+##################
+CreateRCFile
+
+#######################
+# Get the token owner #
+#######################
+TokenOwner
+
+#######################
+# Get the teacher PAT #
+#######################
+DemoPAT
+
+########################
+# Get the instance URL #
+########################
+InstanceURL
+
+#####################
+# Get the class org #
+#####################
+ClassOrg
+
+######################
+# Get the survey URL #
+######################
+SurveyURL
+
+####################
+# Get the appt URL #
+####################
+ApptURL
+
+#########################
+# Check the users shell #
+#########################
+ShellCheck

--- a/script/teach-class
+++ b/script/teach-class
@@ -40,6 +40,7 @@ function GetTask() {
   echo " 6: Create the github-games repos for each student"
   echo " 7: Delete student repos for a specific class"
   echo " 8: Grade client"
+  echo " 9: Create a new partner bootcamp class repository"
 
   ################################
   # Read the task that was input #
@@ -176,6 +177,13 @@ function DoTask() {
     # echo "8: Grade client"
     echo "running script/grade-client"
     script/grade-client
+  ##########
+  # TASK 9 #
+  ##########
+  elif [ "$TASK" -eq 9 ]; then
+    # echo "9: Create a new partner bootcamp class repository"
+    echo "running script/bootcamp-setup"
+    script/bootcamp-setup
   fi
 }
 ################################################################################


### PR DESCRIPTION
This pull request will add a new script that creates a class repository from a different template. The purpose of this will be for the partner bootcamps.

- [x] Add an option to the `teach-class` script
- [ ] Create a template repository in the `githubpartners` organization, similar to http://github.com/githubtraining/caption-this
- [ ] Amend the `bootcamp-setup` script as needed to function in `githubpartners` with correct template repo
- [ ] Amend the `create-repo-bootcamp`script to pull from correct repo in `githubpartners` organization
- [ ] Test