### PR TITLE
Fixes #238 - Don't run Check-Env() if running option 0

### DIFF
--- a/script/teach-class
+++ b/script/teach-class
@@ -95,7 +95,7 @@ function DoTask() {
     ############################################
     COLLAB_REPO_WHITESPACE="$(echo -e "$COLLAB_REPO" | tr -d '[:space:]')"
     COLLAB_REPO=$COLLAB_REPO_WHITESPACE
-  else
+  elif [ "$TASK" -ne 0 ]; then
     ##########################################
     # Validate we have env variables sourced #
     ##########################################


### PR DESCRIPTION
Added check for Option 0 and then don't run the Check_Env() call if we are executing option 0.
Fixes #238 