### PR TITLE
Update super-linter.yml

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -17,9 +17,6 @@ name: Super Linter
 on:
   push:
     branches-ignore: [master]
-    # Remove the line above to run when pushing to master
-  pull_request:
-    branches: [master]
 
 ###############
 # Set the Job #


### PR DESCRIPTION
This PR covers:
- Removing the double jobs of the `super-linter`

We only need it to run on the push and exclude master pushes, as it should have always made it through a PR and doesn't need to run again :)