### PR TITLE
master → $default-branch

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,7 +16,7 @@ name: Super Linter
 #############################
 on:
   push:
-    branches-ignore: [master]
+    branches-ignore: [ $default-branch ]
 
 ###############
 # Set the Job #
@@ -45,5 +45,5 @@ jobs:
         uses: github/super-linter@v3
         env:
           VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: master
+          DEFAULT_BRANCH: $default-branch
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Changes the hardcoded `master` branch to `$default-branch` in the Super Linter configuration file.