### PR TITLE
Include closed issues in get_issues()

### DIFF
--- a/script/create-files
+++ b/script/create-files
@@ -202,7 +202,7 @@ get_existing_files() {
 get_issues() {
   # Get list of issues from the repository (formatted as '$NUM. $TITLE')
   IFS=$'\n' read -d "" -ra issues <<<"$(
-    curl -s -u "$TOKEN_OWNER:$TEACHER_PAT" -X GET "$REPO_URL/issues" | jq -r 'reverse | .[] | "\(.number). \(.title)" | @sh' | tr -d \'
+    curl -s -u "$TOKEN_OWNER:$TEACHER_PAT" -X GET "$REPO_URL/issues?state=all" | jq -r 'reverse | .[] | "\(.number). \(.title)" | @sh' | tr -d \'
   )" >>log.out 2>&1
 }
 


### PR DESCRIPTION
Fixes #262

This PR modifies the `get_issues()` function in `create-files` to include closed issues. This will prevent duplicate issues from being created if the activity issue was closed prior to re-running the script.