### PR TITLE
Upgrade super-linter to v4

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -42,7 +42,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Super Linter
-        uses: github/super-linter@v3
+        uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main


### PR DESCRIPTION
Workflows failing ([example](https://github.com/githubtraining/training-manual/pull/312/checks?check_run_id=3191706199)).

See related issue in github/super-linter: https://github.com/github/super-linter/pull/408
