### PR TITLE
Use Super Linter’s slim image

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -42,7 +42,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Super Linter
-        uses: github/super-linter@v4
+        uses: docker://ghcr.io/github/super-linter:slim-v4
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main


### PR DESCRIPTION
From the [Super Linter documentation](https://github.com/github/super-linter#slim-image):

> The slim `github/super-linter:slim-v4` comes with all supported linters but removes the following:
> 
> - `rust` linters
> - `dotenv` linters
> - `armttk` linters
> - `pwsh` linters
> - `c#` linters
> 
> By removing these linters, we were able to bring the image size down by `2gb` and drastically speed up the build and download time.

Since we don’t use any of the languages listed above in this repo, this should significantly speed up status checks. 