### PR TITLE
Revert "Create .shellcheckrc"

### DIFF
--- a/.github/linters/.shellcheckrc
+++ b/.github/linters/.shellcheckrc
@@ -1,2 +1,0 @@
-# Disable SC1091: Not following: ./.trainingmanualrc: openBinaryFile: does not exist (No such file or directory)
-disable=SC1091


### PR DESCRIPTION
Reverts githubtraining/training-manual#323

I don’t think we should disable this rule universally, as it helps to catch references to files that don’t exist. In this case, we just need to update the comment above the line that sources the `.trainingmanualrc` file as described here: https://github.com/githubtraining/training-manual/pull/315/files#issuecomment-929519658