### PR TITLE
Add .git extension to scratch clone command

### DIFF
--- a/docs/01_getting_ready_for_class.md
+++ b/docs/01_getting_ready_for_class.md
@@ -61,7 +61,7 @@ Now is a good time to create a shortcut to the command line application you will
 Open your chosen shell, and type:
 
 ```sh
-git clone https://github.com/githubschool/scratch
+git clone https://github.com/githubschool/scratch.git
 ```
 
 If the clone is successful you'll see:


### PR DESCRIPTION
This was recently pointed out as a discrepancy in class, and it would be nice to make it consistent with what GitHub.com copies from the clone clipboard.

**Manual:**
The training manual lists the repo url without the `.git` extension.

![Screenshot of training manual git clone line where the repo doesn't have the .git extension](https://user-images.githubusercontent.com/5758031/136974607-e6a3f7b9-d743-4078-9580-508746e37dfd.png)

**GitHub.com:**
GitHub.com's clone button dropdown appends `.git`.

![Screenshot of the clone button dropdown on GitHub.com, which adds the .git extension](https://user-images.githubusercontent.com/5758031/136974611-79b1fe02-fa81-468f-9c8e-9167548261e0.png)


