### PR TITLE
Adding sourcing .trainingmanual.rc to files missing it

### DIFF
--- a/script/check-caption-repo
+++ b/script/check-caption-repo
@@ -2,6 +2,7 @@
 #
 # Check Caption Repo
 
+# shellcheck disable=SC1091
 source "$HOME/.trainingmanualrc"
 
 #################################################################

--- a/script/check-conflict-repos
+++ b/script/check-conflict-repos
@@ -2,6 +2,7 @@
 #
 # Check Conflicts Repo
 
+# shellcheck disable=SC1091
 source "$HOME/.trainingmanualrc"
 
 #################################################################

--- a/script/clean-up-class
+++ b/script/clean-up-class
@@ -2,6 +2,7 @@
 #
 # Cleanup Class
 
+# shellcheck disable=SC1091
 source "$HOME/.trainingmanualrc"
 
 #################################################################

--- a/script/create-practice-repos
+++ b/script/create-practice-repos
@@ -8,6 +8,7 @@
 # We recommend a dedicated service account (e.g. githubteacher) #
 #################################################################
 
+# shellcheck disable=SC1091
 source "$HOME/.trainingmanualrc"
 
 # shellcheck source=script/shared_functions

--- a/script/create-repo
+++ b/script/create-repo
@@ -2,6 +2,7 @@
 #
 # Create Repo
 
+# shellcheck disable=SC1091
 source "$HOME/.trainingmanualrc"
 
 #################################################################

--- a/script/expire-repo
+++ b/script/expire-repo
@@ -2,6 +2,7 @@
 #
 # Expire Repo
 
+# shellcheck disable=SC1091
 source "$HOME/.trainingmanualrc"
 
 #################################################################

--- a/script/grade-client
+++ b/script/grade-client
@@ -2,6 +2,7 @@
 #
 # Grade Client Repo
 
+# shellcheck disable=SC1091
 source "$HOME/.trainingmanualrc"
 
 #################################################################

--- a/script/new-virtual
+++ b/script/new-virtual
@@ -2,6 +2,7 @@
 #
 # New Virtual
 
+# shellcheck disable=SC1091
 source "$HOME/.trainingmanualrc"
 
 #################################################################

--- a/script/remove-repo
+++ b/script/remove-repo
@@ -2,6 +2,7 @@
 #
 # Remove Repo
 
+# shellcheck disable=SC1091
 source "$HOME/.trainingmanualrc"
 
 #################################################################

--- a/script/reset-game
+++ b/script/reset-game
@@ -2,6 +2,7 @@
 #
 # Reset Game
 
+# shellcheck disable=SC1091
 source "$HOME/.trainingmanualrc"
 
 #################################################################

--- a/script/shared_functions
+++ b/script/shared_functions
@@ -2,6 +2,7 @@
 #
 # Shared functions
 
+# shellcheck disable=SC1091
 source "$HOME/.trainingmanualrc"
 
 # shellcheck source=script/ask


### PR DESCRIPTION
Adding sourcing of the config file where it was missing.  It's redundant but safer to add it to shared_functions.  Let me know if I should edit to remove that one.

Fixes #317 