### PR TITLE
Fix default branch

### DIFF
--- a/script/create-repo
+++ b/script/create-repo
@@ -48,9 +48,6 @@ function CreateRepo() {
   # add collaborators
   curl -s -S -i -u "${TOKEN_OWNER}:${TEACHER_PAT}" -X PUT "https://${INSTANCE_URL}/repos/${CLASS_ORG}/${REPO_NAME}/collaborators/${COLLAB}" >>log.out 2>&1
   CloneRepo
-
-  # Set default branch to main
-  curl -s -S -i -u "${TOKEN_OWNER}:${TEACHER_PAT}" -d "{\"default_branch\":\"main\"}" -X PATCH "https://${INSTANCE_URL}/repos/${CLASS_ORG}/${REPO_NAME}" >>log.out 2>&1
 }
 
 function CloneRepo() {

--- a/script/new-virtual
+++ b/script/new-virtual
@@ -76,9 +76,9 @@ function GetDetails() {
 
 function PrettyRepo() {
   TEACHER=$1
-  default_branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
   #set branch protections
   {
+    default_branch=$(curl -s -S -H "Accept: application/vnd.github.v3+json" -u "$TOKEN_OWNER:$TEACHER_PAT" -X GET "https://$INSTANCE_URL/repos/$CLASS_ORG/$REPO_NAME" | jq '.default_branch' | sed -e 's/^"//' -e 's/"$//')
     curl -s -S -i -H "Accept: application/vnd.github.loki-preview+json" -u "$TOKEN_OWNER:$TEACHER_PAT" -d "{ \"required_status_checks\": { \"strict\": false, \"contexts\": [ \"null\" ] }, \"required_pull_request_reviews\": { \"dismissal_restrictions\": { \"users\": [ \"$TEACHER\" ], \"teams\": [ \"null\" ] }, \"dismiss_stale_reviews\": false }, \"enforce_admins\": false, \"restrictions\": { \"users\": [ \"$TEACHER\", \"$TOKEN_OWNER\" ], \"teams\": [ \"null\" ] } }" -X PUT "https://$INSTANCE_URL/repos/$CLASS_ORG/$REPO_NAME/branches/$default_branch/protection"
     curl -s -S -i -H "Accept: application/vnd.github.loki-preview+json" -u "$TOKEN_OWNER:$TEACHER_PAT" -X DELETE "https://$INSTANCE_URL/repos/$CLASS_ORG/$REPO_NAME/branches/$default_branch/protection/required_status_checks"
     #delete labels other than question, duplicate, enhancement, and help wanted

--- a/script/new-virtual
+++ b/script/new-virtual
@@ -76,10 +76,11 @@ function GetDetails() {
 
 function PrettyRepo() {
   TEACHER=$1
+  default_branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
   #set branch protections
   {
-    curl -s -S -i -H "Accept: application/vnd.github.loki-preview+json" -u "$TOKEN_OWNER:$TEACHER_PAT" -d "{ \"required_status_checks\": { \"strict\": false, \"contexts\": [ \"null\" ] }, \"required_pull_request_reviews\": { \"dismissal_restrictions\": { \"users\": [ \"$TEACHER\" ], \"teams\": [ \"null\" ] }, \"dismiss_stale_reviews\": false }, \"enforce_admins\": false, \"restrictions\": { \"users\": [ \"$TEACHER\", \"$TOKEN_OWNER\" ], \"teams\": [ \"null\" ] } }" -X PUT "https://$INSTANCE_URL/repos/$CLASS_ORG/$REPO_NAME/branches/main/protection"
-    curl -s -S -i -H "Accept: application/vnd.github.loki-preview+json" -u "$TOKEN_OWNER:$TEACHER_PAT" -X DELETE "https://$INSTANCE_URL/repos/$CLASS_ORG/$REPO_NAME/branches/main/protection/required_status_checks"
+    curl -s -S -i -H "Accept: application/vnd.github.loki-preview+json" -u "$TOKEN_OWNER:$TEACHER_PAT" -d "{ \"required_status_checks\": { \"strict\": false, \"contexts\": [ \"null\" ] }, \"required_pull_request_reviews\": { \"dismissal_restrictions\": { \"users\": [ \"$TEACHER\" ], \"teams\": [ \"null\" ] }, \"dismiss_stale_reviews\": false }, \"enforce_admins\": false, \"restrictions\": { \"users\": [ \"$TEACHER\", \"$TOKEN_OWNER\" ], \"teams\": [ \"null\" ] } }" -X PUT "https://$INSTANCE_URL/repos/$CLASS_ORG/$REPO_NAME/branches/$default_branch/protection"
+    curl -s -S -i -H "Accept: application/vnd.github.loki-preview+json" -u "$TOKEN_OWNER:$TEACHER_PAT" -X DELETE "https://$INSTANCE_URL/repos/$CLASS_ORG/$REPO_NAME/branches/$default_branch/protection/required_status_checks"
     #delete labels other than question, duplicate, enhancement, and help wanted
     curl -s -S -i -u "$TOKEN_OWNER:$TEACHER_PAT" -X DELETE "https://$INSTANCE_URL/repos/$CLASS_ORG/$REPO_NAME/labels/bug"
     curl -s -S -i -u "$TOKEN_OWNER:$TEACHER_PAT" -X DELETE "https://$INSTANCE_URL/repos/$CLASS_ORG/$REPO_NAME/labels/invalid"
@@ -101,7 +102,7 @@ function PrettyRepo() {
 }
 
 function FinishStrong() {
-  echo "ALL DONE: Remember to enable GitHub Pages on main."
+  echo "ALL DONE: Remember to enable GitHub Pages on $default_branch."
   echo "Good luck with class!"
 }
 


### PR DESCRIPTION
Updating so that it uses the default branch in the template repo instead of always assuming a default of main.  This fixes the issue that if your default branch is something other than main, it doesn't add the PRs properly for conflict-practice repos.  This also correctly detects and uses the default branch for the class repo.

I didn't make any changes to reset-game. https://github.com/githubtraining/training-manual/blob/9e66fc09678dedb993526d369e12ca938d4840fe/script/reset-game#L140  Let me know if I should file an issue for us to fix that one up too.

Closes #321 