### PR TITLE
Enter no longer works to create a branch

### DIFF
--- a/docs/04a_activity_create_branch.md
+++ b/docs/04a_activity_create_branch.md
@@ -9,7 +9,7 @@ Follow these steps to create a new branch in the class repository:
 1. Navigate to **Code** tab of the class repository.
 1. Click the *branch dropdown*.
 1. Enter the branch name `github-username-caption`.
-1. Press `Enter`.
+1. Click on your branch name to create the branch.
 
 When you create a new branch on GitHub, you are automatically switched to your branch. Now, any changes you make to the files in the repository will be applied to this new branch.
 


### PR DESCRIPTION
This was verified in chrome on Mac and edge on Windows when I was teaching my latest class against GHES.  I just checked and enter is no longer valid in the branch drop-down on .com either to create a new branch.