### PR TITLE
Add conditions to retry HTTPie install

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -47,6 +47,13 @@ if ! type -p http &>/dev/null; then
     python -m pip install --upgrade pip setuptools
     # Install HTTPie
     python -m pip install --upgrade httpie
+    # If not HTTPie is not installed above, lets try:
+    # Attempt #1: install without multidict compilation
+    [[ -z $(pip show httpie 2>/dev/null) ]] && MULTIDICT_NO_EXTENSIONS=1 python -m pip install --no-cache-dir httpie
+    # Attempt #2: install older version that does not require multidict
+    [[ -z $(pip show httpie 2>/dev/null) ]] && python -m pip install httpie==2.6.0
+    # Return code for $ERROR_CODE
+    python -m pip show httpie >/dev/null 2>&1
     ;;
   *) echo "Unable to install HTTPie. Please install and try again." && exit 1 ;;
   esac

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -49,11 +49,9 @@ if ! type -p http &>/dev/null; then
     python -m pip install --upgrade httpie
     # If not HTTPie is not installed above, lets try:
     # Attempt #1: install without multidict compilation
-    [[ -z $(pip show httpie 2>/dev/null) ]] && MULTIDICT_NO_EXTENSIONS=1 python -m pip install --no-cache-dir httpie
+    type -p http &>/dev/null || MULTIDICT_NO_EXTENSIONS=1 python -m pip install --no-cache-dir httpie
     # Attempt #2: install older version that does not require multidict
-    [[ -z $(pip show httpie 2>/dev/null) ]] && python -m pip install httpie==2.6.0
-    # Return code for $ERROR_CODE
-    python -m pip show httpie >/dev/null 2>&1
+    type -p http &>/dev/null || python -m pip install httpie==2.6.0
     ;;
   *) echo "Unable to install HTTPie. Please install and try again." && exit 1 ;;
   esac

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -47,10 +47,10 @@ if ! type -p http &>/dev/null; then
     python -m pip install --upgrade pip setuptools
     # Install HTTPie
     python -m pip install --upgrade httpie
-    # If not HTTPie is not installed above, lets try:
-    # Attempt #1: install without multidict compilation
+    # If HTTPie installation is unsuccessful using the method above, try the following:
+    # Attempt #1: Install without multidict compilation
     type -p http &>/dev/null || MULTIDICT_NO_EXTENSIONS=1 python -m pip install --no-cache-dir httpie
-    # Attempt #2: install older version that does not require multidict
+    # Attempt #2: Install older version that does not require multidict
     type -p http &>/dev/null || python -m pip install httpie==2.6.0
     ;;
   *) echo "Unable to install HTTPie. Please install and try again." && exit 1 ;;


### PR DESCRIPTION
Add conditions for installing older versions of httpie if a failure occurs due to multidict dependency related issues 

**Attempt 1:**
```sh
# install without multidict compilation:  
[[ -z $(pip show httpie 2>/dev/null) ]] &&
  MULTIDICT_NO_EXTENSIONS=1 python -m pip install --no-cache-dir httpie
```

**Attempt 2:**
```sh
# install older version without multidict dependency
[[ -z $(pip show httpie 2>/dev/null) ]] && python -m pip install httpie==2.6.0
```


