### PR TITLE
Remove linter workaround now that root issue has been fixed

### DIFF
--- a/.github/linters/.textlintrc
+++ b/.github/linters/.textlintrc
@@ -4,11 +4,7 @@
   },
   "rules": {
     "terminology": {
-      "defaultTerms": true,
-      "exclude": [
-        // Workaround until https://github.com/sapegin/textlint-rule-terminology/issues/38 is fixed
-        "HTML"
-      ]
+      "defaultTerms": true
     }
   }
 }


### PR DESCRIPTION
This workaround can be removed now that https://github.com/sapegin/textlint-rule-terminology/issues/38 has been fixed and included in the latest version of super-linter.