### PR TITLE
Add 'create feedback issues' option to teach-class

### DIFF
--- a/practice-repos/caption-this/participant_baseline.md
+++ b/practice-repos/caption-this/participant_baseline.md
@@ -1,0 +1,4 @@
+## What is your experience with git and GitHub?
+
+Please leave a comment below with your experience with git and GitHub so far.
+Have you used either in the past? What do you expect to learn in this training?

--- a/practice-repos/caption-this/retro_day1.md
+++ b/practice-repos/caption-this/retro_day1.md
@@ -1,0 +1,4 @@
+## Time for a small retro!
+
+Now that you have completed the first day of training, I would like to hear your feedback.
+What was good? What can be improved? What was missing? Any additional comments? Please leave a comment below 👇

--- a/practice-repos/caption-this/retro_day2.md
+++ b/practice-repos/caption-this/retro_day2.md
@@ -1,0 +1,4 @@
+## Time for a small retro!
+
+Now that you have completed the training, I would like to hear your feedback.
+What was good? What can be improved? What was missing? Any additional comments? Please leave a comment below 👇

--- a/script/create-feedback-issues
+++ b/script/create-feedback-issues
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Create feedback issues
+
+# shellcheck disable=SC1091
+source "$HOME/.trainingmanualrc"
+
+# shellcheck source=script/shared_functions
+source ./shared_functions
+
+# Shell variables
+collab_repo=$1
+repo_endpoint="https://$INSTANCE_URL/repos/$CLASS_ORG/$collab_repo"
+repo_url="https://$ROOT_URL/$CLASS_ORG/$collab_repo"
+
+create_feedback_issues() {
+  # Navigate to the practice-repos directory
+  cd "$(dirname "$0")/../practice-repos" || exit
+
+  # Set $practice_repos_dir to the "physical" path of the working directory
+  practice_repos_dir=$(pwd -P)
+
+  # Switch back to the previous directory
+  cd - >/dev/null || exit
+
+  # Create the participant baseline issue
+  create_issue --repo "$collab_repo" --title "❓What is your experience with git and GitHub?" \
+    --body "$(<"$practice_repos_dir/caption-this/participant_baseline.md")"
+
+  # Create the day 1 retro issue
+  create_issue --repo "$collab_repo" --title "🔍 Retro day 1" \
+    --body "$(<"$practice_repos_dir/caption-this/retro_day1.md")"
+
+    # Create the day 2 retro issue
+  create_issue --repo "$collab_repo" --title "🔍 Retro day 2" \
+    --body "$(<"$practice_repos_dir/caption-this/retro_day2.md")"
+}
+
+create_feedback_issues
+
+print_done "Created 3 feedback issues!"

--- a/script/teach-class
+++ b/script/teach-class
@@ -27,6 +27,7 @@ get_task() {
   echo " 6: Create the github-games repos for each student"
   echo " 7: Delete student repos for a specific class"
   echo " 8: Grade client"
+  echo " 9: Create feedback issues"
 
   # Read the task that was input
   read -r TASK
@@ -131,6 +132,12 @@ do_task() {
     # echo "8: Grade client"
     echo "Running script/grade-client"
     ./grade-client
+
+  # TASK 9
+  elif [ "$TASK" -eq 9 ]; then
+    # echo "9: Create feedback issues"
+    echo "Running script/create-feedback-issues"
+    ./create-feedback-issues "$COLLAB_REPO"
   fi
 }
 


### PR DESCRIPTION
This change adds an additional option to the teach-class script that creates a few issues to gather feedback from participants.

Gathering feedback from participants helps us improve the quality of our training. Gathering this feedback could also be done using, for instance, a Miro board. But I feel it's nice to keep it within GitHub.

By choosing option '9' in the teach-class script, three issues will be generated in the caption-this repo:
- What is your experience with git and GitHub?
- Retro day 1
- Retro day 2

Participants can be asked to leave a comment on each of the issues at the appropriate time.

Not everyone might like having these issues in their caption-this repository, so instead of building it into `create-initial-repo`, I made it a separate option.
