### PR TITLE
Adding ssh support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
     "dockerfile": "Dockerfile"
   },
   "features": {
-    "ghcr.io/devcontainers/features/node:1": {}
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers/features/sshd:1": {}
   },
   "postCreateCommand": "bash ./.devcontainer/postCreateCommand.sh"
 }


### PR DESCRIPTION
`./script/teach-class ` need to be run to manage attendees repos on each training, and during the training.
Allowing the ssh to a CodeSpace of the repo is a valuable tool to manage the repo without needing to clone locally or open a full CodeSpace.

cc: @parkerbxyz @amyschoen 