### PR TITLE
Add powershell support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,8 @@
   },
   "features": {
     "ghcr.io/devcontainers/features/node:1": {},
-    "ghcr.io/devcontainers/features/sshd:1": {}
+    "ghcr.io/devcontainers/features/sshd:1": {},
+    "ghcr.io/devcontainers/features/powershell:1": {}
   },
   "postCreateCommand": "bash ./.devcontainer/postCreateCommand.sh"
 }


### PR DESCRIPTION
On this PR I am adding Powershell support to the SSH support.

This allows to run Powershell commands in the same scope of the scripts, allowing to use other scripts to help teachers on the management of the attendees activities repos.

Sample [GitHubDevelopersTrainingTeacherScripts](https://www.powershellgallery.com/packages/GitHubDevelopersTrainingTeacherScripts/0.3.6-preview)

cc: @parkerbxyz @amyschoen 